### PR TITLE
chore(travis): use a build script to deal with branch/tags/master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 language: java
+#
+# use the container based infra and get benefits of the cache
+#
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2
 
 before_install:
-  - sudo wget --no-check-certificate -O /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64
-  - sudo chmod +x /usr/local/bin/confd
+  - mkdir -p $HOME/.local/bin
+  - wget --no-check-certificate -O $HOME/.local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64
+  - chmod +x $HOME/.local/bin/confd
 
-after_script:
-  - mvn site -P publish-site --settings maven-settings.xml
+# skip 'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V'
+install: /bin/true
+
+script:
+  - chmod +x ./scripts/travis_build.sh
+  - ./scripts/travis_build.sh
+

--- a/scripts/travis_build.sh
+++ b/scripts/travis_build.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# adapted from https://raw.githubusercontent.com/openzipkin/zipkin/master/travis/publish.sh
+#
+set -ex
+readonly MVN_OPTS=-Dconfd.local.path.for.tests=$HOME/.local/bin/confd
+
+
+function heartbeat() {
+  # Some operations (for example Bintray GPG signing) run for a long time without output,
+  # causing Travis to time out the build. This is an ugly hack to work around that.
+  hard_timeout=3600  # 1 hour
+  heartbeat_interval=10
+  counter=0
+  while [[ $counter -lt $hard_timeout ]] && kill -0 "$$" 2>/dev/null; do
+    echo "(heartbeat $counter)"
+	counter=$(($counter + $heartbeat_interval))
+	sleep $heartbeat_interval
+  done &
+}
+
+function increment_version() {
+  # TODO this would be cleaner in release.versionPatterns
+  local v=$1
+  if [ -z $2 ]; then
+     local rgx='^((?:[0-9]+\.)*)([0-9]+)($)'
+  else
+     local rgx='^((?:[0-9]+\.){'$(($2-1))'})([0-9]+)(\.|$)'
+     for (( p=`grep -o "\."<<<".$v"|wc -l`; p<$2; p++)); do
+        v+=.0; done; fi
+  val=`echo -e "$v" | perl -pe 's/^.*'$rgx'.*$/$2/'`
+  echo "$v" | perl -pe s/$rgx.*$'/${1}'`printf %0${#val}s $(($val+1))`/
+}
+
+function build_started_by_tag(){
+  if [ "${TRAVIS_TAG}" == "" ]; then
+    echo "[Publishing] This build was not started by a tag, publishing"
+    return 1
+  else
+    echo "[Publishing] This build was started by the tag ${TRAVIS_TAG}, creating release commits"
+    return 0
+  fi
+}
+
+function is_pull_request(){
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "[Not Publishing] This is a Pull Request"
+    return 0
+  else
+    echo "[Publishing] This is not a Pull Request"
+    return 1
+  fi
+}
+
+function is_travis_branch_master(){
+  if [ "${TRAVIS_BRANCH}" = master ]; then
+    echo "[Publishing] Travis branch is master"
+    return 0
+  else
+    echo "[Not Publishing] Travis branch is not master"
+    return 1
+  fi
+}
+
+function check_travis_branch_equals_travis_tag(){
+  #Weird comparison comparing branch to tag because when you 'git push --tags'
+  #the branch somehow becomes the tag value
+  #github issue: https://github.com/travis-ci/travis-ci/issues/1675
+  if [ "${TRAVIS_BRANCH}" != "${TRAVIS_TAG}" ]; then
+    echo "Travis branch does not equal Travis tag, which it should, bailing out."
+    echo "  github issue: https://github.com/travis-ci/travis-ci/issues/1675"
+    exit 1
+  else
+    echo "[Publishing] Branch (${TRAVIS_BRANCH}) same as Tag (${TRAVIS_TAG})"
+  fi
+}
+
+function publish(){
+  echo "[Publishing] Publishing..."
+  mvn clean package $MVN_OPTS
+  mvn site -P publish-site --settings maven-settings.xml $MVN_OPTS
+  echo "[Publishing] Done"
+}
+
+function do_mvn_release(){
+  # TODO this would be cleaner in release.versionPatterns
+  major_minor_revision=$(echo "$TRAVIS_TAG" | cut -f1 -d-)
+  qualifier=$(echo "$TRAVIS_TAG" | cut -f2 -d- -s)
+
+  # do not increment if the version is tentative ex. 1.0.0-rc1
+  if [[ -n "$qualifier" ]]; then
+    new_version=${major_minor_revision}
+  else
+    new_version=$(increment_version "${major_minor_revision}")
+  fi
+  new_version="${new_version}-SNAPSHOT"
+
+  echo "[Publishing] Creating release commits"
+  echo "[Publishing]   Release version: ${TRAVIS_TAG}"
+  echo "[Publishing]   Post-release version: ${new_version}"
+
+  echo "Doing nothing for now, stay tune!"
+#  git checkout -B master
+#
+#  PUBLISHING=true ./gradlew --info --stacktrace release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
+#  echo "[Publishing] Done"
+}
+
+function run_tests(){
+  echo "[Not Publishing] Running tests then exiting."
+  mvn clean test $MVN_OPTS
+}
+
+#----------------------
+# MAIN
+#----------------------
+action=run_tests
+
+if ! is_pull_request; then
+  if build_started_by_tag; then
+    check_travis_branch_equals_travis_tag
+    action=do_mvn_release
+  elif is_travis_branch_master; then
+    action=publish
+  fi
+fi
+
+heartbeat
+$action


### PR DESCRIPTION
* use the travis container based infra (hence no sudo)
* use travis cache (only available on the container based infra)
* use a build script that adjust its behaviour according to the git(hub) state:
  * run tests (and only tests) if inside a PR/branch
  * publish the mvn site if on master
  * get ready for when we will make release