### PR TITLE
move the forceDestToLocalFS to the global config scope

### DIFF
--- a/src/main/java/com/github/nodevops/confd/maven/plugin/model/TemplateConfig.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/model/TemplateConfig.java
@@ -1,19 +1,18 @@
 package com.github.nodevops.confd.maven.plugin.model;
 
 import java.io.File;
+import java.util.UUID;
 
 import lombok.Data;
 
 @Data
 public class TemplateConfig {
-    public static final String DEFAULT_ID = "undef";
-    private String id = DEFAULT_ID;
+    private String id = UUID.randomUUID().toString();
     private File src;
     private String dest;
-    private boolean forceDestToLocalFileSystemType = false;
     private String[] keys;
 
-    public String getResolvedDestPath() {
+    public String getResolvedDestPath(boolean forceDestToLocalFileSystemType) {
         if (forceDestToLocalFileSystemType) {
             File destAsFile = new File(dest);
             return destAsFile.getPath();

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/mojo/ProcessMojo.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/mojo/ProcessMojo.java
@@ -66,7 +66,14 @@ public class ProcessMojo extends AbstractMojo {
             getLog().info("confd:process has been skipped per configuration of the 'confd.skipProcess' parameter.");
             return;
         }
-        getLog().info("confd:process execution");
+        getLog().info("plugin configuration {" +
+            " workingDirectory: " + workingDirectory +
+            ", encoding:" + encoding +
+            ", mkdirs:" + mkdirs +
+            ", skipProcess:" + skipProcess +
+            ", dictionary:" + dictionary +
+            ", processor:" + processor.toString() +
+            "}");
         dictionary = FileUtils.makeAbsoluteIfNeeded(dictionary, basedir);
 
         // the dictionary file must exists

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/utils/WorkingDirectoryUtil.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/utils/WorkingDirectoryUtil.java
@@ -16,7 +16,10 @@ public class WorkingDirectoryUtil {
     private static final char QUOTE = '\'';
     private static final char LINE_SEPARATOR = '\n';
 
-    public static void generateConfdArtefacts(File workingDirectory, List<TemplateConfig> templates) throws IOException {
+    public static void generateConfdArtefacts(
+        File workingDirectory,
+        List<TemplateConfig> templates,
+        boolean forceDestToLocalFileSystemType) throws IOException {
 
         File templatesDirectory = new File(workingDirectory, TEMPLATES_DIRECTORY);
         File tomlDirectory = new File(workingDirectory, CONF_D_DIRECTORY);
@@ -30,12 +33,15 @@ public class WorkingDirectoryUtil {
         for (TemplateConfig tc : templates) {
             String tomlBaseName = FileUtils.basename(tc.getSrc().getAbsolutePath()) + "toml";
             File tomlFile = new File(tomlDirectory, tomlBaseName);
-            writeToml(tomlFile, tc);
+            writeToml(tomlFile, tc, forceDestToLocalFileSystemType);
             FileUtils.copyFileToDirectory(tc.getSrc(), templatesDirectory);
         }
     }
 
-    public static void writeToml(File tomlFile, TemplateConfig tc) throws IOException {
+    public static void writeToml(
+        File tomlFile,
+        TemplateConfig tc,
+        boolean globalForceDestToLocalFileSystemType) throws IOException {
         StringWriter sw = new StringWriter();
         sw.append("[template]")
             .append(LINE_SEPARATOR);
@@ -48,7 +54,7 @@ public class WorkingDirectoryUtil {
 
         sw.append("dest = ")
             .append(QUOTE)
-            .append(tc.getResolvedDestPath())
+            .append(tc.getResolvedDestPath(globalForceDestToLocalFileSystemType))
             .append(QUOTE)
             .append(LINE_SEPARATOR);
 

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/model/TemplateConfigResolvedDestTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/model/TemplateConfigResolvedDestTest.java
@@ -16,16 +16,18 @@ public class TemplateConfigResolvedDestTest {
     public static final String AN_ABSOLUTE_PATH = "/an/absolute/path";
     private final TemplateConfig templateConfig;
     private final String expected;
+    private final boolean forceDestToLocalFileSystemType;
 
 
-    public TemplateConfigResolvedDestTest(TemplateConfig templateConfig, String expected) {
+    public TemplateConfigResolvedDestTest(TemplateConfig templateConfig, String expected, boolean forceDestToLocalFileSystemType) {
         this.templateConfig = templateConfig;
         this.expected = expected;
+        this.forceDestToLocalFileSystemType = forceDestToLocalFileSystemType;
     }
 
     @Test
     public void testGetResolvedDestPath() {
-        assertThat(templateConfig.getResolvedDestPath()).isEqualTo(expected);
+        assertThat(templateConfig.getResolvedDestPath(forceDestToLocalFileSystemType)).isEqualTo(expected);
     }
 
     @Parameterized.Parameters
@@ -34,27 +36,20 @@ public class TemplateConfigResolvedDestTest {
         TemplateConfig c1 = new TemplateConfig();
         c1.setDest(AN_ABSOLUTE_PATH);
 
-        TemplateConfig c2 = new TemplateConfig();
-        c2.setDest(AN_ABSOLUTE_PATH);
-        c2.setForceDestToLocalFileSystemType(false);
-
         List<Object[]> params = new ArrayList<Object[]>(
             Arrays.asList(new Object[][]{
-                {c1, AN_ABSOLUTE_PATH},
-                {c2, AN_ABSOLUTE_PATH},
+                {c1, AN_ABSOLUTE_PATH, false},
             }));
 
         System.out.println("Running testGetResolvedDestPath on a [" + System.getProperty("os.name") + "] system");
         if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
             TemplateConfig c3 = new TemplateConfig();
             c3.setDest(AN_ABSOLUTE_PATH);
-            c3.setForceDestToLocalFileSystemType(true);
-            params.add(new Object[]{c3, "\\an\\absolute\\path"});
+            params.add(new Object[]{c3, "\\an\\absolute\\path", true});
 
             TemplateConfig c4 = new TemplateConfig();
             c4.setDest("C:\\a\\windows\\absolute\\path");
-            c4.setForceDestToLocalFileSystemType(true);
-            params.add(new Object[]{c4, "C:\\a\\windows\\absolute\\path"});
+            params.add(new Object[]{c4, "C:\\a\\windows\\absolute\\path", true});
         }
 
         return params;

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/processors/impl/JavaProcessorImplTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/processors/impl/JavaProcessorImplTest.java
@@ -49,7 +49,7 @@ public class JavaProcessorImplTest extends AbstractTest {
         templateConfig.setDest(destinationFile.getPath());
         templateConfig.setKeys(new String[]{"/web"});
 
-        WorkingDirectoryUtil.writeToml(tomlFile, templateConfig);
+        WorkingDirectoryUtil.writeToml(tomlFile, templateConfig, false);
 
         ProcessorContext context = ProcessorContext.builder()
             .workingDirectory(testDir)
@@ -77,7 +77,7 @@ public class JavaProcessorImplTest extends AbstractTest {
         templateConfig.setDest(destinationFile.getPath());
         templateConfig.setKeys(new String[]{"/web"});
 
-        WorkingDirectoryUtil.writeToml(tomlFile, templateConfig);
+        WorkingDirectoryUtil.writeToml(tomlFile, templateConfig, false);
 
         ProcessorContext context = ProcessorContext.builder()
             .workingDirectory(testDir)

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/processors/impl/LocalConfdProcessorImplTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/processors/impl/LocalConfdProcessorImplTest.java
@@ -55,7 +55,7 @@ public class LocalConfdProcessorImplTest extends AbstractTest {
         templateConfig.setDest(destinationFile.getPath());
         templateConfig.setKeys(new String[]{"/web"});
 
-        WorkingDirectoryUtil.writeToml(tomlFile, templateConfig);
+        WorkingDirectoryUtil.writeToml(tomlFile, templateConfig, false);
 
         ProcessorContext context = ProcessorContext.builder()
             .workingDirectory(testDir)


### PR DESCRIPTION
- move the forceDestToLocalFS to the global config scope (instead of a per template config)
- enhance the log messages
- provide more checks for template config (check against nullity)