### PR TITLE
Enhance feedback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <mockito.version>2.0.42-beta</mockito.version>
         <cucumber-jvm.version>1.2.5</cucumber-jvm.version>
         <cucumber-jvm-deps>1.0.5</cucumber-jvm-deps>
+        <commons-exec.version>1.3</commons-exec.version>
+        <commons-io.version>2.5</commons-io.version>
         <!-- maven plugins -->
         <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
         <maven-plugin-plugin.version>3.2</maven-plugin-plugin.version>
@@ -40,7 +42,6 @@
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <build-helper-maven-plugin.version>1.12</build-helper-maven-plugin.version>
-        <commons-exec.version>1.3</commons-exec.version>
     </properties>
 
     <prerequisites>
@@ -188,6 +189,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
             <version>${commons-exec.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/pom.xml
+++ b/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.nodevops</groupId>
+    <artifactId>simple-with-profile-java-processor</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>fail-because-name-space-with-profile-java-processor</name>
+    <description>Demo project for Confd Maven Plugin</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
+        <confd-maven-plugin.version>0.1.0-SNAPSHOT</confd-maven-plugin.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.nodevops</groupId>
+                <artifactId>confd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- common step shared by all profiles that prepare the config file for further usage /-->
+                        <id>prepare</id>
+                        <goals>
+                            <goal>prepare</goal>
+                        </goals>
+                        <configuration>
+                            <forceDestToLocalFileSystemType>true</forceDestToLocalFileSystemType>
+                            <templates>
+                                <template>
+                                    <id>application.yml</id>
+                                    <src>src/main/confd/templates/application.yml.tmpl</src>
+                                    <dest>${project.basedir}/target/generated-configuration/application.yml</dest>
+                                    <keys>
+                                        <value>/your/namespace</value>
+                                        <value>/runtime</value>
+                                    </keys>
+                                </template>
+                            </templates>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.nodevops</groupId>
+                    <artifactId>confd-maven-plugin</artifactId>
+                    <version>${confd-maven-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+    <profiles>
+        <profile>
+            <id>local</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.nodevops</groupId>
+                        <artifactId>confd-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- we want to generate the config files because we need it to run now /-->
+                                <id>generate</id>
+                                <goals>
+                                    <goal>process</goal>
+                                </goals>
+                                <configuration>
+                                    <processor>
+                                        <name>java-processor</name>
+                                    </processor>
+                                    <dictionary>src/main/confd/dictionaries/local.dict</dictionary>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>delivery</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.nodevops</groupId>
+                        <artifactId>confd-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- common step shared by all profiles that prepare the config file for further usage /-->
+                                <id>prepare</id>
+                                <goals>
+                                    <goal>prepare</goal>
+                                </goals>
+                                <configuration>
+                                    <forceDestToLocalFileSystemType>true</forceDestToLocalFileSystemType>
+                                    <templates>
+                                        <template>
+                                            <id>application.yml</id>
+                                            <dest>/usr/local/appli/config/application.yml</dest>
+                                        </template>
+                                    </templates>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/assembly/confd.xml
+++ b/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/assembly/confd.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>confd</id>
+    <formats>
+        <format>tgz</format>
+    </formats>
+    <baseDirectory>/</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/target/confd</directory>
+            <includes>
+                <include>**</include>
+            </includes>
+            <outputDirectory>/</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/confd/dictionaries/local.dict
+++ b/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/confd/dictionaries/local.dict
@@ -1,0 +1,11 @@
+# in local mode, let's mock the orchestrator_app_id
+/runtime/orchestrator/app/id=bazinga
+#
+/your/namespace/myapp/httpport=8080
+/your/namespace/myapp/tomcat/access/log/dir=target
+/your/namespace/myapp/tomcat/access/log/enabled=false
+/your/namespace/myapp/tomcat/access/log/pattern=combined
+/your/namespace/myapp/tomcat/access/log/prefix=access_log
+/your/namespace/myapp/tomcat/access/log/suffix=.log
+/your/namespace/myapp/management/context/path=/admin
+/your/namespace/myapp/env/name=local

--- a/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/confd/templates/application.yml.tmpl
+++ b/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/confd/templates/application.yml.tmpl
@@ -1,0 +1,18 @@
+server:
+  port: {{getv "/your/namespace/myapp/httpport"}}
+  tomcat:
+    accesslog:
+      directory: {{getv "/your/namespace/myapp/tomcat/access/log/dir"}}
+      enabled: {{getv "/your/namespace/myapp/tomcat/access/log/enabled"}}
+      pattern: {{getv "/your/namespace/myapp/tomcat/access/log/pattern"}}
+      prefix: {{getv "/your/namespace/myapp/tomcat/access/log/prefix"}}
+      suffix: {{getv "/your/namespace/myapp/tomcat/access/log/suffix}}
+
+management:
+  context-path: {{getv "/your/namespace/myapp/management/context/path"}}
+
+info:
+  env:
+    name: {{getv "/your/namespace/myapp/env/name"}}
+  orchestrator:
+    app_id: {{getv "/runtime/orchestrator/app/id"}}

--- a/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/java/com/github/nodevops/SimpleSampleApplication.java
+++ b/src/integration-test/data/projects/fail-because-bad-template-with-profile-java-processor/src/main/java/com/github/nodevops/SimpleSampleApplication.java
@@ -1,0 +1,8 @@
+package com.github.nodevops;
+
+public class SimpleSampleApplication {
+
+    public static void main(String[] args) {
+        System.out.println("I am a simple sample application");
+    }
+}

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/mojo/PrepareMojo.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/mojo/PrepareMojo.java
@@ -13,6 +13,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import com.github.nodevops.confd.maven.plugin.model.TemplateConfig;
+import com.github.nodevops.confd.maven.plugin.utils.PrepareContext;
 import com.github.nodevops.confd.maven.plugin.utils.WorkingDirectoryUtil;
 
 @Mojo(name = "prepare", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = false)
@@ -20,6 +21,11 @@ public class PrepareMojo extends AbstractMojo {
 
     public static final String INDEX_AND_ID_SEPARATOR = ":";
     public static final String ELEMENTS_SEPARATOR = ",";
+    /**
+     * The character encoding scheme to be applied when filtering resources.
+     */
+    @Parameter(property = "encoding", defaultValue = "${project.build.sourceEncoding}")
+    protected String encoding;
     /**
      * The output directory into which to copy the resources.
      */
@@ -103,7 +109,12 @@ public class PrepareMojo extends AbstractMojo {
         // This is the real execution block
         try {
             // generate the "confd like" working directory which will contain the toml and template files
-            WorkingDirectoryUtil.generateConfdArtefacts(workingDirectory, templates, forceDestToLocalFileSystemType);
+            PrepareContext context = PrepareContext.builder()
+                .encoding(encoding)
+                .workingDirectory(workingDirectory)
+                .skipPrepare(skipPrepare)
+                .build();
+            WorkingDirectoryUtil.generateConfdArtefacts(context, templates, forceDestToLocalFileSystemType,getLog());
         } catch (IOException e) {
             throw new MojoExecutionException("Caught an IOException while trying to generate confd artefacts in " +
                 workingDirectory + " for templates " + templates, e);

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/templating/LexicalAnalyzer.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/templating/LexicalAnalyzer.java
@@ -13,7 +13,7 @@ public class LexicalAnalyzer {
 
     public Token nextToken() throws IOException {
         if (!buffer.hasRemaining()) {
-            return new Token(Type.EOF, "", buffer.position());
+            return new Token(TokenType.EOF, "", buffer.position());
         }
         if (!isInTemplateExpression) {
             return nextTokenNotInTemplateExpression();
@@ -31,13 +31,13 @@ public class LexicalAnalyzer {
                 char c2 = buffer.get();
                 if (c2 == '{') {
                     isInTemplateExpression = true;
-                    return new Token(Type.ENTERING_TEMPLATE_EXPRESSION, position);
+                    return new Token(TokenType.ENTERING_TEMPLATE_EXPRESSION, position);
                 } else {
                     sb.append(c).append(c2);
                     return nextLiteralToken(sb);
                 }
             } else {
-                return new Token(Type.LITERAL, sb.toString(), position);
+                return new Token(TokenType.LITERAL, sb.toString(), position);
             }
         } else {
             sb.append(c);
@@ -64,23 +64,23 @@ public class LexicalAnalyzer {
                     c = buffer.get();
                     if (c == '}') {
                         isInTemplateExpression = false;
-                        return new Token(Type.LEAVING_TEMPLATE_EXPRESSION, position);
+                        return new Token(TokenType.LEAVING_TEMPLATE_EXPRESSION, position);
                     } else {
                         backup();
-                        return new Token(Type.OPERAND, "}", position);
+                        return new Token(TokenType.OPERAND, "}", position);
                     }
                 } else {
-                    return new Token(Type.OPERAND, "}", position);
+                    return new Token(TokenType.OPERAND, "}", position);
                 }
             } else if (Character.isDigit(c)) {
                 backup();
                 return nextNumberToken();
             } else {
-                return new Token(Type.OPERAND, String.valueOf(c), position);
+                return new Token(TokenType.OPERAND, String.valueOf(c), position);
             }
             position = buffer.position();
         }
-        return new Token(Type.EOF, position);
+        return new Token(TokenType.EOF, position);
     }
 
     private Token nextNumberToken() {
@@ -97,7 +97,7 @@ public class LexicalAnalyzer {
             sb.append(c);
         }
 
-        return new Token(Type.NUMBER, sb.toString(), position);
+        return new Token(TokenType.NUMBER, sb.toString(), position);
     }
 
     private Token nextStringToken() throws IOException {
@@ -107,11 +107,11 @@ public class LexicalAnalyzer {
         while (buffer.hasRemaining()) {
             char c = buffer.get();
             if (c == '"') {
-                return new Token(Type.STRING, sb.toString(), position);
+                return new Token(TokenType.STRING, sb.toString(), position);
             }
             sb.append(c);
         }
-        return new Token(Type.ERROR, "unterminated quoted string", position);
+        return new Token(TokenType.ERROR, "unterminated quoted string", position);
     }
 
     private Token nextIdentifierToken() {
@@ -128,7 +128,7 @@ public class LexicalAnalyzer {
             sb.append(c);
         }
 
-        return new Token(Type.IDENTIFIER, sb.toString(), position);
+        return new Token(TokenType.IDENTIFIER, sb.toString(), position);
     }
 
     private void skipWhiteSpaces() {
@@ -160,6 +160,6 @@ public class LexicalAnalyzer {
             sb.append(c);
         }
 
-        return new Token(Type.LITERAL, sb.toString(), position);
+        return new Token(TokenType.LITERAL, sb.toString(), position);
     }
 }

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/templating/LexicalAnalyzer.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/templating/LexicalAnalyzer.java
@@ -109,11 +109,9 @@ public class LexicalAnalyzer {
             if (c == '"') {
                 return new Token(Type.STRING, sb.toString(), position);
             }
-
             sb.append(c);
         }
-
-        throw new IOException("unterminated quoted string");
+        return new Token(Type.ERROR, "unterminated quoted string", position);
     }
 
     private Token nextIdentifierToken() {
@@ -134,7 +132,7 @@ public class LexicalAnalyzer {
     }
 
     private void skipWhiteSpaces() {
-        int position = buffer.position();
+        buffer.position();
 
         while (buffer.hasRemaining()) {
             char c = buffer.get();

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/templating/Parser.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/templating/Parser.java
@@ -82,10 +82,11 @@ public class Parser {
             case PARSE:
             default:
                 if (!env.containsKey(keyName)) {
-                        throw new IOException(getErrorMessage("key " + keyName + " does not exist", t));
+                    throw new IOException(getErrorMessage("key " + keyName + " does not exist", t));
                 } else {
-                        sb.append(env.get(keyName));
-                        expectClosingBraces(sc);
+                    keys.add(keyName);
+                    sb.append(env.get(keyName));
+                    expectClosingBraces(sc);
                 }
                 break;
         }
@@ -184,7 +185,7 @@ public class Parser {
 
     }
 
-    public List<String> getGatheredKeys() {
+    public List<String> getTemplateKeys() {
         return keys;
     }
 

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/templating/Token.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/templating/Token.java
@@ -1,24 +1,24 @@
 package com.github.nodevops.confd.maven.plugin.templating;
 
 public class Token {
-    private Type type;
+    private TokenType tokenType;
     private String value;
     private int position;
 
-    public Token(Type type, int position) {
-        this.type = type;
+    public Token(TokenType tokenType, int position) {
+        this.tokenType = tokenType;
         this.value = "";
         this.position = position;
     }
 
-    public Token(Type type, String value, int position) {
-        this.type = type;
+    public Token(TokenType tokenType, String value, int position) {
+        this.tokenType = tokenType;
         this.value = value;
         this.position = position;
     }
 
-    public Type getType() {
-        return this.type;
+    public TokenType getTokenType() {
+        return this.tokenType;
     }
 
     public String getValue() {
@@ -30,6 +30,6 @@ public class Token {
     }
 
     public String toString() {
-        return "Token{type=" + this.type + ", value=\'" + this.value + '\'' + '}';
+        return "Token{tokenType=" + this.tokenType + ", value=\'" + this.value + '\'' + '}';
     }
 }

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/templating/TokenType.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/templating/TokenType.java
@@ -1,6 +1,6 @@
 package com.github.nodevops.confd.maven.plugin.templating;
 
-public enum Type {
+public enum TokenType {
     LITERAL,
     IDENTIFIER,
     STRING,
@@ -11,6 +11,6 @@ public enum Type {
     ERROR,
     EOF;
 
-    Type() {
+    TokenType() {
     }
 }

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/templating/Type.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/templating/Type.java
@@ -8,8 +8,9 @@ public enum Type {
     LEAVING_TEMPLATE_EXPRESSION,
     OPERAND,
     NUMBER,
+    ERROR,
     EOF;
 
-    private Type() {
+    Type() {
     }
 }

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/utils/DictionaryUtil.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/utils/DictionaryUtil.java
@@ -2,13 +2,14 @@ package com.github.nodevops.confd.maven.plugin.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.codehaus.plexus.util.FileUtils;
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
+
+import com.google.common.collect.Maps;
 
 /**
  * Contains some helper methods to handle dictionaries. A dictionary is a file containing key/value pairs. The file may contain comments
@@ -17,7 +18,7 @@ import org.codehaus.plexus.util.StringUtils;
  * <p>
  * Example of valid key/value pairs :
  * <p>
- *
+ * <p>
  * <pre>
  *
  * /web/media_server/address = media.server.com
@@ -30,22 +31,23 @@ import org.codehaus.plexus.util.StringUtils;
  * </pre>
  */
 public class DictionaryUtil {
+    public static final String DOES_NOT_CONTAIN_KEY_VALUE_PAIR_MESSAGE = "does not contain key/value pair";
+    public static final String BAD_KEY_VALUE_FORMAT_FOR_LINE_MESSAGE = "bad key/value format for line";
+    public static final String EMPTY_VALUES_ARE_NOT_ALLOWED_MESSAGE = "empty values are not allowed";
+
     /**
      * Load the <code>dictionary</code> file into a <code>Map</code> according to the <code>encoding</code>.
      * <p>
      * The key names are converted to shell environment variable format. For instance /part1/part2 is converted to PART1_PART2 (the first
      * '/' is removed).
      *
-     * @param dictionary
-     *            the file path to load
-     * @param encoding
-     *            the encoding of the file to load
+     * @param dictionary the file path to load
+     * @param encoding   the encoding of the file to load
      * @return a <code>Map</code> representation of the file
-     * @throws DictionaryException
-     *             if the file cannot be load or if a key/value is not valid.
+     * @throws DictionaryException if the file cannot be load or if a key/value is not valid.
      */
     public static Map<String, String> readDictionaryAsEnvVariables(File dictionary, String encoding) throws DictionaryException {
-        return readDictionnary(dictionary, encoding, true);
+        return readDictionary(dictionary, encoding, true);
     }
 
     /**
@@ -53,43 +55,86 @@ public class DictionaryUtil {
      * <p>
      * The key names format is unchanged
      *
-     * @param dictionary
-     *            the file path to load
-     * @param encoding
-     *            the encoding of the file to load
+     * @param dictionary the file path to load
+     * @param encoding   the encoding of the file to load
      * @return a <code>Map</code> representation of the file
-     * @throws DictionaryException
-     *             if the file cannot be load or if a key/value is not valid.
+     * @throws DictionaryException if the file cannot be load or if a key/value is not valid.
      */
     public static Map<String, String> readDictionaryAsProperties(File dictionary, String encoding) throws DictionaryException {
-        return readDictionnary(dictionary, encoding, false);
+        return readDictionary(dictionary, encoding, false);
     }
 
-    private static Map<String, String> readDictionnary(File dictionary, String encoding, boolean convertToEnv) throws DictionaryException {
+    private static Map<String, String> readDictionary(File dictionary, String encoding, boolean convertToEnv) throws DictionaryException {
         try {
-            List<String> lines = FileUtils.loadFile(dictionary);
-            // the file must contain at least one key/value pair
-            if (lines.isEmpty()) {
-                throw new DictionaryException("dictionary " + dictionary + " does not contain key/value pair");
-            }
-            Map<String, String> env = new HashMap<String, String>();
+            List<String> lines = FileUtils.readLines(dictionary, encoding);
+            Map<String, String> env = Maps.newHashMap();
+            int lineIndex = 0;
             for (String line : lines) {
-                String[] split = line.split("\\s*=\\s*", 2);
+                lineIndex++;
+                if (!(line.isEmpty() || line.startsWith("#"))) {
+                    if (!line.contains("=")) {
+                        throw new DictionaryException(
+                            "dictionary <" +
+                            dictionary +
+                            ":" + lineIndex +
+                            "> " +
+                            BAD_KEY_VALUE_FORMAT_FOR_LINE_MESSAGE +
+                            " <" +
+                            line +
+                            ">");
+                    }
+                    String[] split = line.split("\\s*=\\s*", 2);
 
-                if (split.length != 2) {
-                    throw new DictionaryException("dictionary " + dictionary + " : bad key/value format for " + line);
+                    if (split.length != 2) {
+                        throw new DictionaryException(
+                            "dictionary <" +
+                            dictionary +
+                            ":" +
+                            lineIndex +
+                            "> " +
+                            BAD_KEY_VALUE_FORMAT_FOR_LINE_MESSAGE +
+                            " <" +
+                            line +
+                            ">");
+                    }
+                    if (StringUtils.isEmpty(split[1])) {
+                        throw new DictionaryException(
+                            "dictionary <" +
+                            dictionary +
+                            ":" +
+                            lineIndex +
+                            "> : " +
+                            EMPTY_VALUES_ARE_NOT_ALLOWED_MESSAGE +
+                            " <" +
+                            line +
+                            ">");
+                    }
+                    env.put(normalizeKey(split[0].trim(), convertToEnv), split[1].trim());
                 }
-                if (StringUtils.isEmpty(split[1])) {
-                    throw new DictionaryException("dictionary " + dictionary + " : bad key/value format for " + line);
-                }
-                env.put(normalizeKey(split[0], convertToEnv), split[1]);
-
+            }
+            // the file must contain at least one key/value pair
+            if (env.isEmpty()) {
+                throw new DictionaryException(
+                    "dictionary <" +
+                        dictionary +
+                        "> " +
+                        DOES_NOT_CONTAIN_KEY_VALUE_PAIR_MESSAGE);
             }
             return env;
         } catch (IOException e) {
-            throw new DictionaryException("unable to load " + dictionary, e);
+            throw new DictionaryException(
+                "unable to load file <" +
+                    dictionary +
+                    "> because of IOException with message <" +
+                    e.getMessage() + ">"
+                , e);
         } catch (InvalidKeyFormatException e) {
-            throw new DictionaryException("unable to load " + dictionary, e);
+            throw new DictionaryException(
+                "unable to load file <" +
+                    dictionary +
+                    "> because of an InvalidKeyFormatException with message <" +
+                    e.getMessage() + ">"
+                , e);
         }
     }
 
@@ -97,13 +142,10 @@ public class DictionaryUtil {
      * Convert a key from confd format "/part1/part2/...." to shell variable format "PART1_PART2_...." if the <code>convertToEnv</code> is
      * <code>true</code>, otherwise the key remains unchanged The valid format for the input key is : <code>(/\w+)+</code>
      *
-     * @param key
-     *            the key to convert
-     * @param convertToEnv
-     *            true must convert the key name to to shell variable format
+     * @param key          the key to convert
+     * @param convertToEnv true must convert the key name to to shell variable format
      * @return a new key in shell variable format
-     * @throws DictionaryException
-     *             - If the key format is not valid
+     * @throws DictionaryException - If the key format is not valid
      */
     private static String normalizeKey(String key, boolean convertToEnv) throws InvalidKeyFormatException {
         String result;

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/utils/NamespaceChecker.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/utils/NamespaceChecker.java
@@ -1,0 +1,31 @@
+package com.github.nodevops.confd.maven.plugin.utils;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+public class NamespaceChecker {
+    private final List<String> keys;
+    private final String[] namespaces;
+
+    public NamespaceChecker(List<String> keys, String[] namespaces) {
+        this.keys = keys;
+        this.namespaces = namespaces;
+    }
+
+    public List<String> getUnmatchedKeys() {
+        List<String> offendingKeys = Lists.newArrayList();
+        for (String key : keys) {
+            boolean found = false;
+            for(String ns: namespaces) {
+                if(key.startsWith(ns)) {
+                    found = true;
+                }
+            }
+            if(!found) {
+                offendingKeys.add(key);
+            }
+        }
+        return offendingKeys;
+    }
+}

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/utils/PrepareContext.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/utils/PrepareContext.java
@@ -1,0 +1,14 @@
+package com.github.nodevops.confd.maven.plugin.utils;
+
+import java.io.File;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PrepareContext {
+    private String encoding;
+    private File workingDirectory;
+    private boolean skipPrepare;
+}

--- a/src/main/java/com/github/nodevops/confd/maven/plugin/utils/WorkingDirectoryUtil.java
+++ b/src/main/java/com/github/nodevops/confd/maven/plugin/utils/WorkingDirectoryUtil.java
@@ -51,7 +51,7 @@ public class WorkingDirectoryUtil {
         Parser parser = new Parser(tc.getSrc(), context.getEncoding(), Parser.ParserType.GATHER);
         try {
             parser.parse(Maps.<String, String>newHashMap());
-            List<String> keys = parser.getGatheredKeys();
+            List<String> keys = parser.getTemplateKeys();
             List<String> offendingKeys = new NamespaceChecker(keys, tc.getKeys()).getUnmatchedKeys();
             if (!offendingKeys.isEmpty()) {
                 log.error("=========================================================");

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/AbstractTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/AbstractTest.java
@@ -1,7 +1,23 @@
 package com.github.nodevops.confd.maven.plugin;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.codehaus.plexus.util.FileUtils;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
 public class AbstractTest {
     private final static String BASEDIR;
+    protected static final String ENCODING = "UTF-8";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder(new File(getBaseDir(), "target"));
+
 
     static {
         String basedir = System.getProperty("basedir");
@@ -10,5 +26,15 @@ public class AbstractTest {
 
     protected String getBaseDir() {
         return BASEDIR;
+    }
+
+    protected File createTestFile(String[] lines) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (String s : lines) {
+            sb.append(s).append('\n');
+        }
+        File f = temporaryFolder.newFile("test.dict");
+        FileUtils.fileWrite(f, ENCODING, sb.toString());
+        return f;
     }
 }

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/mojo/PrepareMojoTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/mojo/PrepareMojoTest.java
@@ -35,6 +35,8 @@ public class PrepareMojoTest extends AbstractTest {
 
         PrepareMojo mojo = (PrepareMojo) rule.lookupMojo("prepare", pomFile);
         assertThat(mojo).isNotNull();
+
+        rule.setVariableValueToObject(mojo, "encoding", "UTF-8");
         rule.setVariableValueToObject(mojo, "basedir", basedir);
         rule.setVariableValueToObject(mojo, "workingDirectory", workDirectory);
         mojo.execute();

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/templating/ParserTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/templating/ParserTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import com.github.nodevops.confd.maven.plugin.AbstractTest;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 public class ParserTest extends AbstractTest {
     @Test
@@ -277,5 +278,25 @@ public class ParserTest extends AbstractTest {
         exception.expect(IOException.class);
         exception.expectMessage("test.dict [6,14] : unexpected unclosed action in command");
         parser.parse(env);
+    }
+
+    @Test
+    public void shouldGatherKeys() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir\"}}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = Maps.newHashMap();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8", Parser.ParserType.GATHER);
+        parser.parse(env);
+        assertThat(parser.getGatheredKeys()).containsOnly(
+            "/your/namespace/myapp/httpport",
+            "/your/namespace/myapp/tomcat/access/log/dir",
+            "/your/namespace/myapp/tomcat/access/log/enabled");
     }
 }

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/templating/ParserTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/templating/ParserTest.java
@@ -37,6 +37,11 @@ public class ParserTest extends AbstractTest {
             "  accesslog:\n" +
             "  directory: /var/log/appli\n" +
             "  enabled: true\n");
+        assertThat(parser.getTemplateKeys()).containsOnly(
+            "/your/namespace/myapp/httpport",
+            "/your/namespace/myapp/tomcat/access/log/dir",
+            "/your/namespace/myapp/tomcat/access/log/enabled");
+
     }
 
     @Test
@@ -281,7 +286,7 @@ public class ParserTest extends AbstractTest {
     }
 
     @Test
-    public void shouldGatherKeys() throws IOException {
+    public void shouldGatherKeysInGatherMode() throws IOException {
         String[] templateLines = {
             "server:",
             "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
@@ -294,7 +299,7 @@ public class ParserTest extends AbstractTest {
         File templateFile = createTestFile(templateLines);
         Parser parser = new Parser(templateFile, "UTF-8", Parser.ParserType.GATHER);
         parser.parse(env);
-        assertThat(parser.getGatheredKeys()).containsOnly(
+        assertThat(parser.getTemplateKeys()).containsOnly(
             "/your/namespace/myapp/httpport",
             "/your/namespace/myapp/tomcat/access/log/dir",
             "/your/namespace/myapp/tomcat/access/log/enabled");

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/templating/ParserTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/templating/ParserTest.java
@@ -1,0 +1,281 @@
+package com.github.nodevops.confd.maven.plugin.templating;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.github.nodevops.confd.maven.plugin.AbstractTest;
+import com.google.common.collect.ImmutableMap;
+
+public class ParserTest extends AbstractTest {
+    @Test
+    public void shouldSuccessWithSimpleTemplate() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir\"}}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        String parsedTemplate = parser.parse(env);
+        assertThat(parsedTemplate).isEqualTo("server:\n" +
+            "  port: 8080\n" +
+            "tomcat:\n" +
+            "  accesslog:\n" +
+            "  directory: /var/log/appli\n" +
+            "  enabled: true\n");
+    }
+
+    @Test
+    public void shouldFailBecauseMissingKey() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir\"}}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [6,19] : key /your/namespace/myapp/tomcat/access/log/enabled does not exist");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseUnfinishedCommandAtEOF() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir\"}}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [6,67] : unexpected unclosed action in command");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseUnfinishedCommandNotAtEOF() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir\"",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,65] : unexpected unclosed action in command");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseUnfinishedCommand() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir\" anotherFunc }}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,66] : expected }}  but found anotherFunc");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseWrongNumberOfArgsForGetv() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv }}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,20] : wrong number of args for 'getv': want 1 got 0");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseWrongNumberOfArgsForGetvAtEOF() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\" }}",
+            "  enabled: {{getv ",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [6,18] : wrong number of args for 'getv': want 1 got 0");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseUnbalancedComma() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{getv \"/your/namespace/myapp/tomcat/access/log/dir}}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,21] : unterminated quoted string");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseUnsupportedFunction() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{anotherFunc \"/your/namespace/myapp/tomcat/access/log/dir\" }}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,15] : function 'anotherFunc' not supported");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseMissingSupportedFunction() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{ \"/your/namespace/myapp/tomcat/access/log/dir\" }}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,17] : expected 'getv' but found something that looks like a key");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseMissingValueForCommand() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{ }}",
+            "  enabled: {{getv \"/your/namespace/myapp/tomcat/access/log/enabled\"}}",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [5,16] : missing value for command");
+        parser.parse(env);
+    }
+
+    @Test
+    public void shouldFailBecauseUnfinishedTemplateAtEOF() throws IOException {
+        String[] templateLines = {
+            "server:",
+            "  port: {{getv \"/your/namespace/myapp/httpport\"}}",
+            "tomcat:",
+            "  accesslog:",
+            "  directory: {{ getv \"/your/namespace/myapp/tomcat/access/log/dir\" }}",
+            "  enabled: {{ ",
+        };
+        Map<String, String> env = ImmutableMap.<String, String>builder()
+            .put("/your/namespace/myapp/httpport", "8080")
+            .put("/your/namespace/myapp/tomcat/access/log/dir", "/var/log/appli")
+            .put("/your/namespace/myapp/tomcat/access/log/enabled", "true")
+            .build();
+        File templateFile = createTestFile(templateLines);
+        Parser parser = new Parser(templateFile, "UTF-8");
+        exception.expect(IOException.class);
+        exception.expectMessage("test.dict [6,14] : unexpected unclosed action in command");
+        parser.parse(env);
+    }
+}

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/utils/DictionaryUtilTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/utils/DictionaryUtilTest.java
@@ -1,53 +1,46 @@
 package com.github.nodevops.confd.maven.plugin.utils;
 
+import static com.github.nodevops.confd.maven.plugin.utils.DictionaryUtil.BAD_KEY_VALUE_FORMAT_FOR_LINE_MESSAGE;
+import static com.github.nodevops.confd.maven.plugin.utils.DictionaryUtil.DOES_NOT_CONTAIN_KEY_VALUE_PAIR_MESSAGE;
+import static com.github.nodevops.confd.maven.plugin.utils.DictionaryUtil.EMPTY_VALUES_ARE_NOT_ALLOWED_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 
-import org.codehaus.plexus.util.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
 
 import com.github.nodevops.confd.maven.plugin.AbstractTest;
 
 public class DictionaryUtilTest extends AbstractTest {
 
-    private static final String ENCODING = "UTF-8";
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder(new File(getBaseDir(), "target"));
 
     @Test
     public void shouldFailDueToEmptyDictionary() throws Exception {
         File testFile = temporaryFolder.newFile("test.dict");
         exception.expect(DictionaryException.class);
-        exception.expectMessage("does not contain key/value pair");
+        exception.expectMessage(DOES_NOT_CONTAIN_KEY_VALUE_PAIR_MESSAGE);
         DictionaryUtil.readDictionaryAsEnvVariables(testFile, ENCODING);
     }
 
     @Test
     public void shouldFailDueToMalFormedKeyDictionary() throws Exception {
         String[] lines = {
-                "/web/mediaserver/url=http://media01.server.com/",
-                "",
-                "# Missing the first /",
-                "web/database/username=user01",
-                "",
-                "/web/database/password=pwd01",
+            "/web/mediaserver/url=http://media01.server.com/",
+            "",
+            "# Missing the first /",
+            "web/database/username=user01",
+            "",
+            "/web/database/password=pwd01",
         };
 
         File testFile = createTestFile(lines);
 
         exception.expect(DictionaryException.class);
-        exception.expectCause(CoreMatchers.is(IsInstanceOf.<Throwable> instanceOf(InvalidKeyFormatException.class)));
+        exception.expectCause(CoreMatchers.is(IsInstanceOf.<Throwable>instanceOf(InvalidKeyFormatException.class)));
 
         DictionaryUtil.readDictionaryAsEnvVariables(testFile, ENCODING);
 
@@ -56,19 +49,19 @@ public class DictionaryUtilTest extends AbstractTest {
     @Test
     public void shouldFailDueToDictionaryWithoutKeyValue() throws Exception {
         String[] lines = {
-                "# This file contains only comments and blank lines",
-                "# One blank line",
-                "",
-                "# Two blank lines",
-                "",
-                "",
-                "# End of file",
+            "# This file contains only comments and blank lines",
+            "# One blank line",
+            "",
+            "# Two blank lines",
+            "",
+            "",
+            "# End of file",
         };
 
         File testFile = createTestFile(lines);
 
         exception.expect(DictionaryException.class);
-        exception.expectMessage("does not contain key/value pair");
+        exception.expectMessage(DOES_NOT_CONTAIN_KEY_VALUE_PAIR_MESSAGE);
         DictionaryUtil.readDictionaryAsEnvVariables(testFile, ENCODING);
 
     }
@@ -77,13 +70,29 @@ public class DictionaryUtilTest extends AbstractTest {
     public void shouldFailDueToKeyWithoutValue() throws Exception {
 
         String[] lines = {
-                "/web/mediaserver/url =",
+            "/web/mediaserver/url =",
         };
 
         File testFile = createTestFile(lines);
 
         exception.expect(DictionaryException.class);
-        exception.expectMessage("bad key/value format for");
+        exception.expectMessage(EMPTY_VALUES_ARE_NOT_ALLOWED_MESSAGE);
+
+        DictionaryUtil.readDictionaryAsEnvVariables(testFile, ENCODING);
+
+    }
+
+    @Test
+    public void shouldFailDueToLineWithoutEquals() throws Exception {
+
+        String[] lines = {
+            "/web/mediaserver/url",
+        };
+
+        File testFile = createTestFile(lines);
+
+        exception.expect(DictionaryException.class);
+        exception.expectMessage(BAD_KEY_VALUE_FORMAT_FOR_LINE_MESSAGE);
 
         DictionaryUtil.readDictionaryAsEnvVariables(testFile, ENCODING);
 
@@ -92,8 +101,8 @@ public class DictionaryUtilTest extends AbstractTest {
     @Test
     public void shouldSuccessWithSpacesAroundEqualSeparator() throws Exception {
         String[] lines = {
-                "/part1/part2   =   value1",
-                "/part1/part3 = value2",
+            "/part1/part2   =   value1",
+            "/part1/part3 = value2",
         };
 
         File testFile = createTestFile(lines);
@@ -105,11 +114,11 @@ public class DictionaryUtilTest extends AbstractTest {
     }
 
     @Test
-    public void shouldTrimKeyName() throws Exception {
+    public void shouldTrimKeyNamesAndValues() throws Exception {
         String[] lines = {
-                "/part1/part2   =   value1",
-                "    /part1/part3  =   value2",
-                "\t/part1/part4\t=\tthe value 3"
+            "/part1/part2   =   value1",
+            "    /part1/part3  =   value2",
+            "\t/part1/part4\t=\tthe value 3"
         };
 
         File testFile = createTestFile(lines);
@@ -124,9 +133,9 @@ public class DictionaryUtilTest extends AbstractTest {
     @Test
     public void shouldKeyEqualCharactersInValue() throws Exception {
         String[] lines = {
-                "/part1/part2 = value1",
-                "/part1/part3 = value2=toto",
-                "/part1/part4 = the value 3 is = to 3"
+            "/part1/part2 = value1",
+            "/part1/part3 = value2=toto",
+            "/part1/part4 = the value 3 is = to 3"
         };
 
         File testFile = createTestFile(lines);
@@ -141,8 +150,8 @@ public class DictionaryUtilTest extends AbstractTest {
     @Test
     public void shouldSuccessWithValidKeyValues() throws Exception {
         String[] lines = {
-                "/part1/part11_sub1/part111 = value1",
-                "/part2/part22_sub2/part222 = value2",
+            "/part1/part11_sub1/part111 = value1",
+            "/part2/part22_sub2/part222 = value2",
         };
 
         File testFile = createTestFile(lines);
@@ -154,13 +163,5 @@ public class DictionaryUtilTest extends AbstractTest {
         assertThat(env).containsEntry("PART2_PART22_SUB2_PART222", "value2");
     }
 
-    private File createTestFile(String[] lines) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        for (String s : lines) {
-            sb.append(s).append('\n');
-        }
-        File f = temporaryFolder.newFile("test.dict");
-        FileUtils.fileWrite(f, ENCODING, sb.toString());
-        return f;
-    }
+
 }

--- a/src/test/java/com/github/nodevops/confd/maven/plugin/utils/NamespaceCheckerTest.java
+++ b/src/test/java/com/github/nodevops/confd/maven/plugin/utils/NamespaceCheckerTest.java
@@ -1,0 +1,54 @@
+package com.github.nodevops.confd.maven.plugin.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class NamespaceCheckerTest {
+
+    @Test
+    public void testGetUnmatchedKeysWhenNoOffendingKeys() {
+        List<String> keys = Lists.newArrayList(
+            "/ns1/one",
+            "/ns2/one",
+            "/ns1/two",
+            "/ns2/gna"
+        );
+
+        String[] namespaces = {"/ns1", "/ns2"};
+        List<String> offending = new NamespaceChecker(keys, namespaces).getUnmatchedKeys();
+        assertThat(offending).isEmpty();
+    }
+
+    @Test
+    public void testGetUnmatchedKeysWhenOffendingKeys1() {
+        List<String> keys = Lists.newArrayList(
+            "/ns1/one",
+            "/ns2/one",
+            "/ns1/two",
+            "/ns2/gna"
+        );
+
+        String[] namespaces = {"/ns1", "/ns3"};
+        List<String> offending = new NamespaceChecker(keys, namespaces).getUnmatchedKeys();
+        assertThat(offending).isNotEmpty().containsOnly("/ns2/one", "/ns2/gna");
+    }
+
+    @Test
+    public void testGetUnmatchedKeysWhenOffendingKeys2() {
+        List<String> keys = Lists.newArrayList(
+            "/ns1/one",
+            "/ns2/one",
+            "/ns1/two",
+            "/ns2/gna"
+        );
+
+        String[] namespaces = {"/ns2", "/ns3"};
+        List<String> offending = new NamespaceChecker(keys, namespaces).getUnmatchedKeys();
+        assertThat(offending).isNotEmpty().containsOnly("/ns1/one", "/ns1/two");
+    }
+}


### PR DESCRIPTION
- (prepare): warn users about keys needed by the templates but excluded by the namespaces
- (java-processor) warn users when some keys in local dictionaries are not used in the templates
- show off the offending template when encountering a parsing error

fix #22 #14 #21 
